### PR TITLE
Removed the need for template_id in {% handlebars %} templatetag.

### DIFF
--- a/ember/templatetags/ember.py
+++ b/ember/templatetags/ember.py
@@ -118,7 +118,12 @@ class HandlebarsNode(VerbatimNode):
 
     def render(self, context):
         output = super(HandlebarsNode, self).render(context)
-        head_script = '<script type="text/x-handlebars" data-template-name="%s">' % self.template_id
+
+        if self.template_id:
+            head_script = '<script type="text/x-handlebars" data-template-name="%s">' % self.template_id
+        else:
+            head_script = '<script type="text/x-handlebars">'
+
         return '''
         %s
         %s
@@ -131,12 +136,17 @@ def handlebars(parser, token):
     text_and_nodes = verbatim_tags(parser, token, endtagname='endhandlebars')
     # Extract template id from token
     tokens = token.split_contents()
-    stripquote = lambda s: s[1:-1] if s[:1] == '"' else s
-    try:
-        tag_name, template_id = map(stripquote, tokens[:2])
-    except ValueError:
-        raise template.TemplateSyntaxError, '%s tag requires exactly one argument' % token.split_contents()[0]
-    return HandlebarsNode(template_id, text_and_nodes)
+
+    if len(tokens) > 1:
+        stripquote = lambda s: s[1:-1] if s[:1] == '"' else s
+
+        try:
+            tag_name, template_id = map(stripquote, tokens[:2])
+        except ValueError:
+            raise template.TemplateSyntaxError, '%s tag requires exactly one argument' % token.split_contents()[0]
+        return HandlebarsNode(template_id, text_and_nodes)
+    else:
+        return HandlebarsNode(None, text_and_nodes)
 
 
 def include_js(filename):

--- a/ember/tests.py
+++ b/ember/tests.py
@@ -21,6 +21,25 @@ class TemplateTagsTest(TestCase):
         self.failUnless('<p>' in rendered)
         self.failUnless('</p>' in rendered)
 
+    def test_rendering_without_template_id(self):
+        '''Should render handlebars without data-template-name'''
+        t = Template('''
+            {% load ember %}
+            {% handlebars %}
+                <p>{{name}}</p>
+                {{{rawname}}}
+                No data-template-name in here.
+            {% endhandlebars %}
+            ''')
+        rendered = t.render(Context())
+
+        self.failUnless('<script type="text/x-handlebars">' in rendered)
+        self.failUnless('{{name}}' in rendered)
+        self.failUnless('{{{rawname}}}' in rendered)
+        # HTML should not be escaped
+        self.failUnless('<p>' in rendered)
+        self.failUnless('</p>' in rendered)
+
     def test_rendering_with_tags(self):
         '''Should process django template tags'''
         t = Template('''


### PR DESCRIPTION
Removed the need for template_id so you can do this inside a django-template:

```
{% load ember %}
{% handlebars %}
    {{#view App.MyView}}
        <p>{{view.someVariable}}</p>
        <p>No data-template-name in here.</p>
    {{/view}}
{% endhandlebars %}
```

and:

```
{% handlebars %}
    {{view App.MySpecialButton}}
{% endhandlebars %}
```
