### PR TITLE
Implemented a generic ember escape tag for Django templates and a linkTo helper.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -125,6 +125,48 @@ The following block will be rendered in your page:
         <p>Max: {{max}}</p>
     <script>
 
+There is a linkTo helper:
+
+.. code-block:: html+django
+
+    <li class="nav">{% linkto "about" %}About{% endlinkto %}</li>
+
+The following block will be rendered in your page:
+
+.. code-block:: html
+
+    <li class="nav">{{#linkTo "about"}}About{{/linkTo}}</li>
+    
+When using ``verbatim`` style tags sometimes it is hard to spot what 
+is Ember and what is Django; the purpose of this generic ``ember`` tag is 
+making it easier.
+    
+Usage:
+    
+.. code-block:: html+django
+
+    {% ember varname %}
+    {% ember #tagname arg1 "arg2" ... argn %} ... {% ember /tagname %}
+
+    {# example: #}
+    {% ember #if spam %}
+         SPAM: {% ember spam %}
+    {% ember else %}
+         No spam for you. Try with eggs.
+    {% ember /if %}
+    
+This will render as:
+    
+.. code-block:: html
+
+    {{varname}}
+    {{#tagname arg1 "arg2" ... argn}} ... {{/tagname}}
+
+    {{#if spam}}
+         SPAM: {{spam}}
+    {{else}}
+         No spam for you. Try with eggs.
+    {{/if}}
 
 
 LICENSE

--- a/doc/templatetags.rst
+++ b/doc/templatetags.rst
@@ -84,6 +84,50 @@ The following block will be rendered in your page:
         <p>Max: {{max}}</p>
     <script>
 
+There is a linkTo helper:
+
+.. code-block:: html+django
+
+    <li class="nav">{% linkto "about" %}About{% endlinkto %}</li>
+
+The following block will be rendered in your page:
+
+.. code-block:: html
+
+    <li class="nav">{{#linkTo "about"}}About{{/linkTo}}</li>
+    
+When using ``verbatim`` style tags sometimes it is hard to spot what 
+is Ember and what is Django; the purpose of this generic ``ember`` tag is 
+making it easier.
+    
+Usage:
+    
+.. code-block:: html+django
+
+    {% ember varname %}
+    {% ember #tagname arg1 "arg2" ... argn %} ... {% ember /tagname %}
+
+    {# example: #}
+    {% ember #if spam %}
+         SPAM: {% ember spam %}
+    {% ember else %}
+         No spam for you. Try with eggs.
+    {% ember /if %}
+    
+This will render as:
+    
+.. code-block:: html
+
+    {{varname}}
+    {{#tagname arg1 "arg2" ... argn}} ... {{/tagname}}
+
+    {{#if spam}}
+         SPAM: {{spam}}
+    {{else}}
+         No spam for you. Try with eggs.
+    {{/if}}
+
+    
 .. _`Django.js`: http://pypi.python.org/pypi/django.js
 .. _`Handlebars.js`: http://handlebarsjs.com/
 .. _`Ember.js`: http://emberjs.com/

--- a/ember/tests.py
+++ b/ember/tests.py
@@ -75,6 +75,44 @@ class TemplateTagsTest(TestCase):
         self.assertIn('<p>', rendered)
         self.assertIn('</p>', rendered)
 
+    def test_rendering_linkto(self):
+        '''Test the linkto tag'''
+        t = Template('''
+            {% load ember %}
+            <li class="nav">{% linkto "about" %}About{% endlinkto %}</li>
+            ''')
+        rendered = t.render(Context())
+
+        self.assertIn('<li class="nav">{{#linkTo "about"}}About{{/linkTo}}</li>', rendered)
+
+    def test_rendering_ember(self):
+        '''Test the ember escape tag'''
+        c = Context()
+        t1 = Template('''
+            {% load i18n ember %}
+            {% ember #if isAuthenticated %}
+                <h1>{% trans "Hi," %} {% ember User.firstName %}</h1>
+            {% ember else %}
+                <p>{% trans "Please, sign-in." %}</p>
+            {% ember /if %}
+            ''')
+        rendered = t1.render(c)
+        load = '''{% load i18n ember %}'''
+        t2 = Template(load + '''{% trans "Hi," %}''')
+        msg1 = t2.render(c)
+        t3 = Template(load + '''{% trans "Please, sign-in." %}''')
+        msg2 = t3.render(c)
+        # No trace of the tags
+        self.assertNotIn('ember', rendered)
+        self.assertNotIn('{%', rendered)
+        self.assertNotIn('%}', rendered)
+        # Ember tags
+        self.assertIn('{{#if isAuthenticated}}', rendered)
+        self.assertIn('{{else}}', rendered)
+        self.assertIn('{{/if}}', rendered)
+        self.assertIn('<h1>' + msg1 + ' {{User.firstName}}</h1>', rendered)
+        self.assertIn('<p>' + msg2 + '</p>', rendered)        
+        
     @override_settings(DEBUG=True)
     def test_handlebars_js_unminified(self):
         '''Should include unminified Handlebars library when DEBUG=True'''


### PR DESCRIPTION
Cleaned up the history, hope its OK now.

```
C:\github-forks\django-ember>python manage.py test ember
Creating test database for alias 'default'...
...................
----------------------------------------------------------------------
Ran 19 tests in 0.018s                    
```
